### PR TITLE
permit defaults for no-build-vignettes and no-manual to be configured

### DIFF
--- a/R/drat_builder.R
+++ b/R/drat_builder.R
@@ -13,8 +13,8 @@ main <- function(args=commandArgs(TRUE)) {
   --install-local        as --install, but install in a local library
   --no-fetch             skip fetch
   --no-commit            skip commit
-  --no-build-vignettes   skip vignettes (default behavior, can override per package)
-  --no-manual            skip manual (default behavior, can override per package)
+  --no-build-vignettes   skip vignettes (default behaviour, can override per package)
+  --no-manual            skip manual (default behaviour, can override per package)
   --drop-history         drop all git history' -> doc
   oo <- options(warnPartialMatchArgs=FALSE)
   if (isTRUE(oo$warnPartialMatchArgs)) {
@@ -53,7 +53,7 @@ main <- function(args=commandArgs(TRUE)) {
 build <- function(package_list="packages.txt",
                   install=FALSE, install_local=FALSE,
                   no_fetch=FALSE, no_commit=FALSE,
-                  no_build_vignettes=FALSE, no_manual=TRUE,
+                  no_build_vignettes=TRUE, no_manual=TRUE,
                   drop_history=FALSE) {
   defaults <- list(vignettes = !(no_build_vignettes), manual = !(no_manual))
   pkgs <- read_packages(package_list)


### PR DESCRIPTION
This just adds a command line option and propagates it through which allows the defaults to be configured for turning off building manual and vignettes.

I left the default configuration the way you had it (no manual, yes vignettes), but I think (no, no) is a better default (e.g. matches what `install_github` defaults to).  It doesn't make sense that `install` defaults to `false` but `vignettes` defaults to true, since in general we cannot assume we can build the vignette without install the suggested packages.  More generally, building vignettes can be very slow, and just adds another point of failure.  `install_github` has already trodden this path, and revoked the building of vignettes and installing of suggested packages by default, so we can learn from history here.
