### PR TITLE
switch from https to ssh

### DIFF
--- a/R/drat_builder.R
+++ b/R/drat_builder.R
@@ -362,7 +362,7 @@ package_sha <- function(p) {
 
 package_github_url <- function(p) {
   prefix <- "git@github.com:"
-  prefix <- "https://github.com/"
+#  prefix <- "https://github.com/"
   paste0(prefix, paste(p[["user"]], p[["repo"]], sep="/"), ".git")
 }
 


### PR DESCRIPTION
When I try and use drat.builder with a private repository I get the following error which is fixed by switching from https to ssh

```r
*** [fetch] poissonconsulting/poisreport
Error in call_system(Sys_which("git"), args, ...) : Running command:
  '/usr/bin/git' clone --mirror -- https://github.com/poissonconsulting/poisreport.git packages_src/poissonconsulting/poisreport
had status 128
Program output:
------------------------------------------------------------------------------------
Cloning into bare repository 'packages_src/poissonconsulting/poisreport'...
error: cannot run rpostback-askpass: No such file or directory
fatal: could not read Username for 'https://github.com': Device not configured
------------------------------------------------------------------------------------
> traceback()
8: stop(paste(msg, collapse = "\n"))
7: call_system(Sys_which("git"), args, ...)
6: call_git(c("clone", opts, "--", url, dest))
5: git_clone(package_github_url(p), dp, "--mirror")
4: fetch_package(packages[p, ])
3: fetch_package_sources(pkgs)
2: drat.builder::build(no_commit = TRUE, drop_history = TRUE) at drat-update.R#27
1: ps_drat_update("~/Code/dratprivate")
```